### PR TITLE
Add a simple but broken example

### DIFF
--- a/example/a.py
+++ b/example/a.py
@@ -1,0 +1,12 @@
+from b import B
+
+
+class A:
+    def __init__(self, value: int):
+        self.value = value
+
+    def get_b(self) -> B:
+        return B(self.value)
+
+    def __str__(self) -> str:
+        return f"A({self.value})"

--- a/example/b.py
+++ b/example/b.py
@@ -1,0 +1,12 @@
+from a import A
+
+
+class B:
+    def __init__(self, value: int):
+        self.value = value
+
+    def get_a(self) -> A:
+        return A(self.value)
+
+    def __str__(self) -> str:
+        return f"B({self.value})"

--- a/example/main.py
+++ b/example/main.py
@@ -1,0 +1,8 @@
+from a import A
+from b import B
+
+my_a = A(1)
+my_b = B(2)
+
+print(my_a.get_b())
+print(my_b.get_a())


### PR DESCRIPTION
This is a simple motivating example. It shows a couple of simple classes that have a circular dependency.

Notice, however, that this is not a circular dependency in terms of evaluation (i.e. there is no circular logic anywhere in terms of evaluation). However, it is a circular dependency in terms of definitions.

Attempting to run `main.py` will result in the following error:

```
Traceback (most recent call last):
  File "main.py", line 1, in <module>
    from a import A
  File "a.py", line 1, in <module>
    from b import B
  File "b.py", line 1, in <module>
    from a import A
ImportError: cannot import name 'A' from partially initialized module 'a' (most likely due to a circular import) (a.py)
```

This happens because, while evaluating `b.py`, we encounter the statement `from a import A`. However, we only got as far as line 1 when evaluating A, which means that the name 'A' has not yet been added to that module, and is therefore not available for us to import.

There are several options available for us here. To start exploring them, check #2.