### PR TITLE
Delayed access (fully working)

### DIFF
--- a/02-delayed-access-still-broken/b.py
+++ b/02-delayed-access-still-broken/b.py
@@ -5,7 +5,7 @@ class B:
     def __init__(self, value: int):
         self.value = value
 
-    def get_a(self) -> a.A:
+    def get_a(self) -> "a.A":
         return a.A(self.value)
 
     def __str__(self) -> str:


### PR DESCRIPTION
A quick search online will yield a few options for how to deal with circular type dependencies. Those include:

1. Wrapping the type in quotes.
2. Enabling postponed evaluation.

Those two methods work pretty much the same way: Type annotations are treated by Python as strings until they are executed, and only the would the actual type get evaluated.

For simplicity's sake, let's just wrap the type in quotes.

Once we do, we finally have everything a working example.

Running `main.py` works as expected and prints:
```
B(1)
A(2)
```

This is great, but we might be able to make it even better. See #4 to find out how.