### PR TITLE
An even better delayed access

### DIFF
--- a/03-working-delayed-access/b.py
+++ b/03-working-delayed-access/b.py
@@ -1,12 +1,17 @@
-import a
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from a import A
 
 
 class B:
     def __init__(self, value: int):
         self.value = value
 
-    def get_a(self) -> "a.A":
-        return a.A(self.value)
+    def get_a(self) -> "A":
+        from a import A
+
+        return A(self.value)
 
     def __str__(self) -> str:
         return f"B({self.value})"


### PR DESCRIPTION
At this point, we may be pretty happy with ourselves and decide to optimise things even more.

We may notice that we only need `a.A` when `get_a` is called. So why not avoid importing the module `a` altogether until we *really* need it.

To do this, we:
1. Quote the type to avoid Python trying to evaluate it at definition time.
1. Have a top-level import for `A`, but only when type checking to stop type checkers from complaining that they can't find it.
2. Import `A` when running `get_a`.

We find that this approach also works pretty well:
```
B(1)
A(2)
```

It might seem like we have arrived at an ideal set up here. However, there be dragons in #5.