### PR TITLE
Things get messy

### DIFF
--- a/04-even-better-delayed-access/c.py
+++ b/04-even-better-delayed-access/c.py
@@ -1,0 +1,13 @@
+from a import A
+
+
+class C:
+    def __init__(self, value: int):
+        self.value = value
+        self.a = A(value)
+
+    def get_a(self) -> A:
+        return self.a
+
+    def __str__(self) -> str:
+        return f"C({self.value})"

--- a/04-even-better-delayed-access/main.py
+++ b/04-even-better-delayed-access/main.py
@@ -1,8 +1,11 @@
 from a import A
 from b import B
+from c import C
 
 my_a = A(1)
 my_b = B(2)
+my_c = C(3)
 
 print(my_a.get_b())
 print(my_b.get_a())
+print(my_c.get_a())


### PR DESCRIPTION
The combination of type checking import guards and delayed imports worked great for our toy example. We got it working and even saved ourselves from having to import `A` except when we really need it.

However, in the real world, things can get pretty complicated:
1. We often need to use the same dependency in lots of places. It's not going to make sense for us to repeat the same import statement everywhere we need to use one. Things can get messy really quickly.
2. We don't really have a good systematic way to figure out whether an import should be a normal one or a delayed one. We probably start out with all imports being regular imports until we hit a circular import, at which point we would switch some of them to be delayed imports in order to fix the issue.

In this example, we add a new module `c.py`. `C` depends on `A` in a couple of locations. Seems simple enough.

We even use `C` in our `main.py`. We run it and confirm that everything is working:

```
B(1)
A(2)
A(3)
```

If this doesn't seem so bad, you may want to check #6.