### PR TITLE
It's broken now

### DIFF
--- a/05-things-get-messy/b.py
+++ b/05-things-get-messy/b.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
 
+from c import C
+
 if TYPE_CHECKING:
     from a import A
 
@@ -7,11 +9,15 @@ if TYPE_CHECKING:
 class B:
     def __init__(self, value: int):
         self.value = value
+        self.c = C(value)
 
     def get_a(self) -> "A":
         from a import A
 
         return A(self.value)
+
+    def get_c(self) -> C:
+        return self.c
 
     def __str__(self) -> str:
         return f"B({self.value})"


### PR DESCRIPTION
Turns out, `B` will also need to have a small runtime dependency on `C`.

That should be a relatively simple change.

However, after we make the change, we hit that same circular import issue again:

```
Traceback (most recent call last):
  File "main.py", line 1, in <module>
    from a import A
  File "a.py", line 1, in <module>
    from b import B
  File "b.py", line 3, in <module>
    from c import C
  File "c.py", line 1, in <module>
    from a import A
ImportError: cannot import name 'A' from partially initialized module 'a' (most likely due to a circular import) (a.py)
```

Now what? Find out in #7.