### PR TITLE
Keep it simple

### DIFF
--- a/06-its-broken-now/a.py
+++ b/06-its-broken-now/a.py
@@ -1,12 +1,14 @@
-from b import B
+from __future__ import annotations
+
+import b
 
 
 class A:
     def __init__(self, value: int):
         self.value = value
 
-    def get_b(self) -> B:
-        return B(self.value)
+    def get_b(self) -> b.B:
+        return b.B(self.value)
 
     def __str__(self) -> str:
         return f"A({self.value})"

--- a/06-its-broken-now/b.py
+++ b/06-its-broken-now/b.py
@@ -1,22 +1,18 @@
-from typing import TYPE_CHECKING
+from __future__ import annotations
 
-from c import C
-
-if TYPE_CHECKING:
-    from a import A
+import a
+import c
 
 
 class B:
     def __init__(self, value: int):
         self.value = value
-        self.c = C(value)
+        self.c = c.C(value)
 
-    def get_a(self) -> "A":
-        from a import A
+    def get_a(self) -> a.A:
+        return a.A(self.value)
 
-        return A(self.value)
-
-    def get_c(self) -> C:
+    def get_c(self) -> c.C:
         return self.c
 
     def __str__(self) -> str:

--- a/06-its-broken-now/c.py
+++ b/06-its-broken-now/c.py
@@ -1,12 +1,14 @@
-from a import A
+from __future__ import annotations
+
+import a
 
 
 class C:
     def __init__(self, value: int):
         self.value = value
-        self.a = A(value)
+        self.a = a.A(value)
 
-    def get_a(self) -> A:
+    def get_a(self) -> a.A:
         return self.a
 
     def __str__(self) -> str:

--- a/06-its-broken-now/main.py
+++ b/06-its-broken-now/main.py
@@ -1,10 +1,12 @@
-from a import A
-from b import B
-from c import C
+from __future__ import annotations
 
-my_a = A(1)
-my_b = B(2)
-my_c = C(3)
+import a
+import b
+import c
+
+my_a = a.A(1)
+my_b = b.B(2)
+my_c = c.C(3)
 
 print(my_a.get_b())
 print(my_b.get_a())


### PR DESCRIPTION
Instead of relying on a manually curated, ad-hoc combination of delayed imports, we can go back to the solution we had in the 3rd example.

Let's also enable postponed evaluation everywhere so we don't have to worry about putting quotes around types. We do this by adding `from __future__ import annotations` to the top of every file we have.

Our code is now much more sensible and readable. We don't have to worry about whether any particular import needs to be delayed or not, and we also don't have to worry about runtime or definition circularlity causing our app to crash!

The only cost here is that imported names are slightly longer now, but that doesn't seem so bad compared to what we had to deal with before.